### PR TITLE
Add mixin for file input type

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -302,6 +302,13 @@ module.exports = function (fields, options) {
                     maxlength: 18
                 }
             },
+            'input-file': {
+                path: 'partials/forms/input-text-group',
+                renderWith: inputText,
+                options: {
+                    type: 'file'
+                }
+            },
             textarea: {
                 path: 'partials/forms/textarea-group',
                 renderWith: inputText


### PR DESCRIPTION
This could be done with `input-text` and overriding the type in field config, but it seems super nasty to specify a text input for something which is explicitly *not* a text input.