### PR TITLE
Refactor to load field config from locals

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,23 @@ npm install [--save] hmpo-template-mixins;
 var express = require('express');
 
 var i18n = require('i18n-future');
+var mixins = require('hmpo-template-mixins');
 
 app.set('view engine', 'html');
 app.set('views', path.join(__dirname, '/views'));
 
 app.use(i18n.middleware());
-app.use(require('hmpo-template-mixins')({ sharedTranslationsKey: 'passport.renew' }));
+app.use(mixins());
 
 app.use(function (req, res) {
     // NOTE: res.locals.partials has been set.
-
     res.render('example-template');
 });
 ```
+
+If rendering as part of a hof controller's middleware chain then the field configuration will automatically be set to `res.locals.options.fields` by the controller, and will be loaded from here by the mixins.
+
+Alternatively, if not using hof controllers, you can explicitly set field configuration with instantiating the middleware by passing a `fields` option. This should not be used for dynamic field configuration.
 
 ## Translation
 
@@ -48,6 +52,10 @@ Prefixes keys for translation - Default: ''
 ### translate
 
 Defines a custom translation method - Default: `req.translate`
+
+### fields
+
+Allows for manually setting static field configuration - Default: null
 
 ## Mustache mixins available
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # passports-template-mixins
 A middleware that exposes a series of Mustache mixins on `res.locals` to ease usage of forms, translations, and some other things.
 
-It takes in two arguments, a `fields` object containing field configuration, and an [options object](#options).
-
 ## Installation
 
 ```javascript
@@ -16,13 +14,11 @@ var express = require('express');
 
 var i18n = require('i18n-future');
 
-var fields = require('./routes/renew-your-passport/fields');
-
 app.set('view engine', 'html');
 app.set('views', path.join(__dirname, '/views'));
 
 app.use(i18n.middleware());
-app.use(require('hmpo-template-mixins')(fields, { sharedTranslationsKey: 'passport.renew' }));
+app.use(require('hmpo-template-mixins')({ sharedTranslationsKey: 'passport.renew' }));
 
 app.use(function (req, res) {
     // NOTE: res.locals.partials has been set.

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -10,15 +10,20 @@ var Hogan = require('hogan.js'),
 // This returns a middleware that places mixins against the `res.locals` object.
 //
 // It should be given:
-// - fields: the data needed to generate mixins options, etc.
 // - options:
 //   - viewDirectory: the folder in which templates are found in.
 //   - viewEngine: the type of view, defaults to 'html'.
 //   - sharedTranslationsKey: used to find translations relatively within
 //     the translations.json. Useful for field and button labels.
-module.exports = function (fields, options) {
+module.exports = function (options, deprecated) {
 
-    fields = fields || {};
+    if (arguments.length === 2) {
+        /*eslint no-console: 0*/
+        console.warn('hof-template-mixins: Passing field config to mixins is deprecated');
+        console.warn('hof-template-mixins: Field config will be loaded from res.locals.options.fields');
+        options = deprecated;
+    }
+
     options = options || {};
 
     var viewsDirectory = options.viewsDirectory || path.resolve(__dirname, '../');
@@ -47,8 +52,8 @@ module.exports = function (fields, options) {
         return [relativeTemplatePath, compiledTemplate];
     }).object().value();
 
-    function maxlength(key) {
-        var validation = fields[key] && fields[key].validate || [];
+    function maxlength(field) {
+        var validation = field.validate || [];
         var ml = _.findWhere(validation, { type: 'maxlength' }) || _.findWhere(validation, { type: 'exactlength' });
         if (ml) {
             return _.isArray(ml.arguments) ? ml.arguments[0] : ml.arguments;
@@ -57,8 +62,8 @@ module.exports = function (fields, options) {
         }
     }
 
-    function type(key) {
-        return fields[key] && fields[key].type || 'text';
+    function type(field) {
+        return field.type || 'text';
     }
 
     function classNameString(name) {
@@ -69,10 +74,10 @@ module.exports = function (fields, options) {
         }
     }
 
-    function classNames(key, prop) {
+    function classNames(field, prop) {
         prop = prop || 'className';
-        if (fields[key] && fields[key][prop]) {
-            return classNameString(fields[key][prop]);
+        if (field[prop]) {
+            return classNameString(field[prop]);
         } else {
             return '';
         }
@@ -84,7 +89,7 @@ module.exports = function (fields, options) {
 
         var hoganRender = function (text, ctx) {
             if (!text) { return ''; }
-            ctx = _.extend({}, res.locals, ctx);
+            ctx = Object.assign({}, res.locals, ctx);
             return Hogan.compile(text).render(ctx);
         };
 
@@ -99,8 +104,8 @@ module.exports = function (fields, options) {
             return translated !== key ? translated : null;
         };
 
-        var getTranslationKey = function (key, property) {
-            return fields && fields[key] && fields[key][property] ? fields[key][property] : 'fields.' + key + '.' + property;
+        var getTranslationKey = function (field, key, property) {
+            return field[property] ? field[property] : 'fields.' + key + '.' + property;
         };
 
         /*
@@ -124,21 +129,20 @@ module.exports = function (fields, options) {
         };
 
         function inputText(key, extension) {
-            var hKey = getTranslationKey(key, 'hint');
-            var lKey = getTranslationKey(key, 'label');
+            var field = Object.assign({}, this.options.fields[key]);
+            var hKey = getTranslationKey(field, key, 'hint');
+            var lKey = getTranslationKey(field, key, 'label');
             var hint = conditionalTranslate(hKey);
 
             var required = function isRequired() {
                 var r = false;
 
-                if (fields[key]) {
-                    if (fields[key].required !== undefined) {
-                        return fields[key].required;
-                    } else if (fields[key].validate) {
-                        var hasRequiredValidator = _.indexOf(fields[key].validate, 'required') !== -1;
+                if (field.required !== undefined) {
+                    return field.required;
+                } else if (field.validate) {
+                    var hasRequiredValidator = _.indexOf(field.validate, 'required') !== -1;
 
-                        return hasRequiredValidator ? true : false;
-                    }
+                    return hasRequiredValidator ? true : false;
                 }
 
                 return r;
@@ -147,29 +151,29 @@ module.exports = function (fields, options) {
             extension = extension || {};
 
             var autocomplete;
-            if (fields[key] && typeof fields[key].autocomplete === 'string') {
-                autocomplete = fields[key].autocomplete;
+            if (typeof field.autocomplete === 'string') {
+                autocomplete = field.autocomplete;
             } else if (typeof extension.autocomplete === 'string' && extension.autocomplete) {
                 autocomplete = extension.autocomplete;
             }
 
-            return _.extend(extension, {
+            return Object.assign(extension, {
                 id: key,
-                className: extension.className || classNames(key),
-                type: extension.type || type(key),
+                className: extension.className || classNames(field),
+                type: extension.type || type(field),
                 value: this.values && this.values[key],
                 label: t(lKey),
-                labelClassName: classNames(key, 'labelClassName') || 'form-label-bold',
+                labelClassName: classNames(field, 'labelClassName') || 'form-label-bold',
                 hint: hint,
                 hintId: extension.hintId || (hint ? key + '-hint' : null),
                 error: this.errors && this.errors[key],
-                maxlength: maxlength(key) || extension.maxlength,
+                maxlength: maxlength(field) || extension.maxlength,
                 required: required,
                 pattern: extension.pattern,
                 date: extension.date,
                 autocomplete: autocomplete,
-                child: fields[key] && fields[key].child,
-                attributes: fields[key] && fields[key].attributes,
+                child: field.child,
+                attributes: field.attributes,
                 renderChild: renderChild.bind(this)
             });
         }
@@ -179,7 +183,7 @@ module.exports = function (fields, options) {
                 if (this.child) {
                     var templateString = getTemplate(this.child, this.toggle);
                     var template = Hogan.compile(templateString);
-                    return template.render(_.extend({
+                    return template.render(Object.assign({
                         renderMixin: function () {
                             return function () {
                                 if (this.child && this[this.child]) {
@@ -196,7 +200,8 @@ module.exports = function (fields, options) {
 
         function optionGroup(key, opts) {
             opts = opts || {};
-            var legend = fields[key] && fields[key].legend;
+            var field = Object.assign({}, this.options.fields[key]);
+            var legend = field.legend;
             var legendClassName;
             var legendValue = 'fields.' + key + '.legend';
             if (legend) {
@@ -213,8 +218,8 @@ module.exports = function (fields, options) {
                 legend: t(legendValue),
                 legendClassName: legendClassName,
                 role: opts.type === 'radio' ? 'radiogroup' : 'group',
-                hint: conditionalTranslate(getTranslationKey(key, 'hint')),
-                options: _.map(fields[key] && fields[key].options, function (obj) {
+                hint: conditionalTranslate(getTranslationKey(field, key, 'hint')),
+                options: _.map(field.options, function (obj) {
                     var selected = false, label, value, toggle, child;
 
                     if (typeof obj === 'string') {
@@ -243,28 +248,29 @@ module.exports = function (fields, options) {
                         child: child
                     };
                 }, this),
-                className: classNames(key),
+                className: classNames(field),
                 renderChild: renderChild.bind(this)
             };
         }
 
         function checkbox(key, opts) {
             opts = opts || {};
+            var field = Object.assign({}, this.options.fields[key]);
             opts.required = opts.required || false;
-            opts.toggle = fields[key] && fields[key].toggle;
+            opts.toggle = field.toggle;
             var selected = false;
-            var fieldLabel = fields && fields[key] ? fields[key].label : false;
+            var fieldLabel = field.label ? field.label : false;
             if (this.values && this.values[key] !== undefined) {
                 selected = this.values[key].toString() === 'true';
             }
-            return _.extend(opts, {
+            return Object.assign(opts, {
                 key: key,
                 error: this.errors && this.errors[key],
                 invalid: this.errors && this.errors[key] && opts.required,
                 label: t(fieldLabel || 'fields.' + key + '.label'),
                 selected: selected,
-                className: classNames(key) || 'block-label',
-                child: fields[key] && fields[key].child,
+                className: classNames(field) || 'block-label',
+                child: field.child,
                 renderChild: renderChild.bind(this)
             });
         }
@@ -372,11 +378,12 @@ module.exports = function (fields, options) {
                     * props: '[value] [id]'
                     */
                     return function (key) {
+                        var field = Object.assign({}, this.options.fields[key]);
                         key = hoganRender(key, this);
                         // Exact unless there is a inexact property against the fields key.
-                        var isExact = fields[key] ? fields[key].inexact !== true : true;
+                        var isExact = field.inexact !== true;
 
-                        var autocomplete = fields[key] && fields[key].autocomplete || {};
+                        var autocomplete = field.autocomplete || {};
                         if (autocomplete === 'off') {
                             autocomplete = {
                                 day: 'off',
@@ -414,6 +421,8 @@ module.exports = function (fields, options) {
         _.each(mixins, function (mixin, name) {
             var handler = _.isFunction(mixin.handler) ? mixin.handler : function () {
                 return function (key) {
+                    this.options = this.options || {};
+                    this.options.fields = this.options.fields || {};
                     key = hoganRender(key, this);
                     return compiled[mixin.path]
                         .render(mixin.renderWith.call(this, key, _.isFunction(mixin.options)

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -25,6 +25,7 @@ module.exports = function (options, deprecated) {
     }
 
     options = options || {};
+    options.fields = options.fields || {};
 
     var viewsDirectory = options.viewsDirectory || path.resolve(__dirname, '../');
     var viewEngine = options.viewEngine || 'html';
@@ -129,7 +130,7 @@ module.exports = function (options, deprecated) {
         };
 
         function inputText(key, extension) {
-            var field = Object.assign({}, this.options.fields[key]);
+            var field = Object.assign({}, this.options.fields[key] || options.fields[key]);
             var hKey = getTranslationKey(field, key, 'hint');
             var lKey = getTranslationKey(field, key, 'label');
             var hint = conditionalTranslate(hKey);
@@ -200,7 +201,7 @@ module.exports = function (options, deprecated) {
 
         function optionGroup(key, opts) {
             opts = opts || {};
-            var field = Object.assign({}, this.options.fields[key]);
+            var field = Object.assign({}, this.options.fields[key] || options.fields[key]);
             var legend = field.legend;
             var legendClassName;
             var legendValue = 'fields.' + key + '.legend';
@@ -255,7 +256,7 @@ module.exports = function (options, deprecated) {
 
         function checkbox(key, opts) {
             opts = opts || {};
-            var field = Object.assign({}, this.options.fields[key]);
+            var field = Object.assign({}, this.options.fields[key] || options.fields[key]);
             opts.required = opts.required || false;
             opts.toggle = field.toggle;
             var selected = false;
@@ -378,7 +379,7 @@ module.exports = function (options, deprecated) {
                     * props: '[value] [id]'
                     */
                     return function (key) {
-                        var field = Object.assign({}, this.options.fields[key]);
+                        var field = Object.assign({}, this.options.fields[key] || options.fields[key]);
                         key = hoganRender(key, this);
                         // Exact unless there is a inexact property against the fields key.
                         var isExact = field.inexact !== true;

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -15,7 +15,11 @@ describe('Template Mixins', function () {
     beforeEach(function () {
         req = {};
         res = {
-            locals: {}
+            locals: {
+                options: {
+                    fields: {}
+                }
+            }
         };
         next = sinon.stub();
     });
@@ -48,7 +52,7 @@ describe('Template Mixins', function () {
         describe('input-text', function () {
 
             beforeEach(function () {
-                middleware = mixins({}, { translate: translate });
+                middleware = mixins({ translate: translate });
             });
 
             it('adds a function to res.locals', function () {
@@ -70,10 +74,6 @@ describe('Template Mixins', function () {
             });
 
             it('looks up default field label if nothing is set', function () {
-                middleware = mixins({
-                    'field-name': {
-                    }
-                });
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -82,12 +82,12 @@ describe('Template Mixins', function () {
             });
 
             it('passes child from field config', function () {
-                middleware = mixins({
+                middleware(req, res, next);
+                res.locals.options.fields = {
                     'field-name': {
                         child: 'a child'
                     }
-                });
-                middleware(req, res, next);
+                };
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
                     child: 'a child'
@@ -95,11 +95,11 @@ describe('Template Mixins', function () {
             });
 
             it('uses label when available for the field', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         label: 'Label text'
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -108,7 +108,7 @@ describe('Template Mixins', function () {
             });
 
             it('prefixes translation lookup with namespace if provided', function () {
-                middleware = mixins({}, { translate: translate, sharedTranslationsKey: 'name.space' });
+                middleware = mixins({ translate: translate, sharedTranslationsKey: 'name.space' });
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -117,11 +117,11 @@ describe('Template Mixins', function () {
             });
 
             it('should have an autocomplete setting if specified', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'autocomplete': 'custom'
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -130,10 +130,6 @@ describe('Template Mixins', function () {
             });
 
             it('should default to no autocomplete attribute ', function () {
-                middleware = mixins({
-                    'field-name': {
-                    }
-                });
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -142,11 +138,11 @@ describe('Template Mixins', function () {
             });
 
             it('should have classes if one or more were specified against the field', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'className': ['abc', 'def']
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -155,13 +151,13 @@ describe('Template Mixins', function () {
             });
 
             it('uses maxlength property set at a field level over default option', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'validate': [
                             { type: 'maxlength', arguments: 10 }
                         ]
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['input-phone']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -171,11 +167,12 @@ describe('Template Mixins', function () {
 
             it('uses locales translation property', function () {
                 var translate = sinon.stub().withArgs('field-name.label').returns('Field name');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'label': 'field-name.label'
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['input-phone']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -185,10 +182,11 @@ describe('Template Mixins', function () {
 
             it('includes a hint if it is defined in the locales', function () {
                 var translate = sinon.stub().withArgs('field-name.hint').returns('Field hint');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -198,11 +196,12 @@ describe('Template Mixins', function () {
 
             it('includes a hint if it is defined in translation', function () {
                 var translate = sinon.stub().withArgs('field-name.hint').returns('Field hint');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'hint': 'field-name.hint'
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -211,11 +210,13 @@ describe('Template Mixins', function () {
             });
 
             it('does not include a hint if it is not defined in translation', function () {
-                middleware = mixins({
+                var translate = sinon.stub().withArgs('field-name.hint').returns(null);
+                res.locals.options.fields = {
                     'field-name': {
                         'hint': 'field-name.hint'
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -224,9 +225,6 @@ describe('Template Mixins', function () {
             });
 
             it('sets `labelClassName` to "form-label-bold" by default', function () {
-                middleware = mixins({
-                    'field-name': {}
-                }, { translate: translate });
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -235,11 +233,11 @@ describe('Template Mixins', function () {
             });
 
             it('overrides `labelClassName` when set in field options', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         labelClassName: 'visuallyhidden'
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -248,11 +246,11 @@ describe('Template Mixins', function () {
             });
 
             it('sets all classes of `labelClassName` option', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         labelClassName: ['abc', 'def']
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -261,13 +259,13 @@ describe('Template Mixins', function () {
             });
 
             it('sets additional element attributes', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         attributes: [
                             { attribute: 'autocomplete', value: 'true' }
                         ]
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -278,12 +276,12 @@ describe('Template Mixins', function () {
             });
 
             it('allows configuration of a non-required input with a visuallyhidden label', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         required: false,
                         labelClassName: 'visuallyhidden'
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -293,9 +291,9 @@ describe('Template Mixins', function () {
             });
 
             it('by default, assumes the field isn\'t required', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {}
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -304,11 +302,11 @@ describe('Template Mixins', function () {
             });
 
             it('allows configuration of required status with the required property', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         required: true
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -317,11 +315,11 @@ describe('Template Mixins', function () {
             });
 
             it('allows configuration of required status with the required validator', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         validate: ['required']
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -330,12 +328,12 @@ describe('Template Mixins', function () {
             });
 
             it('the required property takes precedence over the required validator', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         required: false,
                         validate: ['required']
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -348,7 +346,7 @@ describe('Template Mixins', function () {
         describe('input-date', function () {
 
             beforeEach(function () {
-                middleware = mixins(translate, {});
+                middleware = mixins({ translate: translate });
             });
 
             it('adds a function to res.locals', function () {
@@ -368,12 +366,12 @@ describe('Template Mixins', function () {
             });
 
             it('renders 5 times if the field is marked as inexact', function () {
-                var middlewareWithFieldNameMarkedAsInexact = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'inexact': true
                     }
-                });
-                middlewareWithFieldNameMarkedAsInexact(req, res, next);
+                };
+                middleware(req, res, next);
                 res.locals['input-date']().call(res.locals, 'field-name');
                 render.callCount.should.be.equal(5);
             });
@@ -404,12 +402,12 @@ describe('Template Mixins', function () {
             describe('autocomplete', function () {
 
                 it('should have a sufix of -day -month and -year', function () {
-                    var autocompletemiddleware = mixins({
+                    res.locals.options.fields = {
                         'field-name': {
                             'autocomplete': 'bday'
                         }
-                    });
-                    autocompletemiddleware(req, res, next);
+                    };
+                    middleware(req, res, next);
                     res.locals['input-date']().call(res.locals, 'field-name');
 
                     render.called;
@@ -432,7 +430,7 @@ describe('Template Mixins', function () {
                 });
 
                 it('should be set as exact values if an object is given', function () {
-                    var autocompletemiddleware = mixins({
+                    res.locals.options.fields = {
                         'field-name': {
                             'autocomplete': {
                                 day: 'day-type',
@@ -440,8 +438,8 @@ describe('Template Mixins', function () {
                                 year: 'year-type'
                             }
                         }
-                    });
-                    autocompletemiddleware(req, res, next);
+                    };
+                    middleware(req, res, next);
                     res.locals['input-date']().call(res.locals, 'field-name');
 
                     render.called;
@@ -464,12 +462,12 @@ describe('Template Mixins', function () {
                 });
 
                 it('should set autocomplete to off if off is specified', function () {
-                    var autocompletemiddleware = mixins({
+                    res.locals.options.fields = {
                         'field-name': {
                             'autocomplete': 'off'
                         }
-                    });
-                    autocompletemiddleware(req, res, next);
+                    };
+                    middleware(req, res, next);
                     res.locals['input-date']().call(res.locals, 'field-name');
 
                     render.called;
@@ -516,7 +514,7 @@ describe('Template Mixins', function () {
             });
 
             it('prefixes translation lookup with namespace if provided', function () {
-                middleware = mixins({}, { translate: translate, sharedTranslationsKey: 'name.space' });
+                middleware = mixins({ translate: translate, sharedTranslationsKey: 'name.space' });
                 middleware(req, res, next);
                 res.locals['input-date']().call(res.locals, 'field-name');
 
@@ -559,7 +557,7 @@ describe('Template Mixins', function () {
         describe('input-number', function () {
 
             beforeEach(function () {
-                middleware = mixins({}, { translate: translate });
+                middleware = mixins({ translate: translate });
             });
 
             it('adds a function to res.locals', function () {
@@ -585,7 +583,7 @@ describe('Template Mixins', function () {
         describe('input-submit', function () {
 
             beforeEach(function () {
-                middleware = mixins({}, { translate: translate });
+                middleware = mixins({ translate: translate });
             });
 
             it('adds a function to res.locals', function () {
@@ -615,7 +613,7 @@ describe('Template Mixins', function () {
             });
 
             it('prefixes translation lookup with namespace if provided', function () {
-                middleware = mixins({}, { translate: translate, sharedTranslationsKey: 'name.space' });
+                middleware = mixins({ translate: translate, sharedTranslationsKey: 'name.space' });
                 middleware(req, res, next);
                 res.locals['input-submit']().call(res.locals, 'button-id');
                 render.should.have.been.calledWith(sinon.match({
@@ -628,7 +626,7 @@ describe('Template Mixins', function () {
         describe('textarea', function () {
 
             beforeEach(function () {
-                middleware = mixins({}, { translate: translate });
+                middleware = mixins({ translate: translate });
             });
 
             it('adds a function to res.locals', function () {
@@ -650,7 +648,7 @@ describe('Template Mixins', function () {
             });
 
             it('prefixes translation lookup with namespace if provided', function () {
-                middleware = mixins({}, { translate: translate, sharedTranslationsKey: 'name.space' });
+                middleware = mixins({ translate: translate, sharedTranslationsKey: 'name.space' });
                 middleware(req, res, next);
                 res.locals.textarea().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -659,11 +657,11 @@ describe('Template Mixins', function () {
             });
 
             it('should have classes if one or more were specified against the field', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'className': ['abc', 'def']
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals.textarea().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -672,13 +670,13 @@ describe('Template Mixins', function () {
             });
 
             it('uses maxlength property set at a field level over default option', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'validate': [
                             { type: 'maxlength', arguments: 10 }
                         ]
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals.textarea().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -688,11 +686,12 @@ describe('Template Mixins', function () {
 
             it('uses locales translation property', function () {
                 var translate = sinon.stub().withArgs('field-name.label').returns('Field name');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'label': 'field-name.label'
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals.textarea().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -701,9 +700,9 @@ describe('Template Mixins', function () {
             });
 
             it('sets `labelClassName` to "form-label-bold" by default', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {}
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['textarea']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -712,11 +711,11 @@ describe('Template Mixins', function () {
             });
 
             it('overrides `labelClassName` when set in field options', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'labelClassName': 'visuallyhidden'
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['textarea']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -725,11 +724,11 @@ describe('Template Mixins', function () {
             });
 
             it('sets all classes of `labelClassName` option', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         labelClassName: ['abc', 'def']
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['textarea']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -738,14 +737,14 @@ describe('Template Mixins', function () {
             });
 
             it('sets additional element attributes', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         attributes: [
                             { attribute: 'spellcheck', value: 'true' },
                             { attribute: 'autocapitalize', value: 'sentences' }
                         ]
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['textarea']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -761,7 +760,7 @@ describe('Template Mixins', function () {
         describe('checkbox', function () {
 
             beforeEach(function () {
-                middleware = mixins({}, { translate: translate });
+                middleware = mixins({ translate: translate });
             });
 
             it('adds a function to res.locals', function () {
@@ -783,7 +782,7 @@ describe('Template Mixins', function () {
             });
 
             it('prefixes translation lookup with namespace if provided', function () {
-                middleware = mixins({}, { translate: translate, sharedTranslationsKey: 'name.space' });
+                middleware = mixins({ translate: translate, sharedTranslationsKey: 'name.space' });
                 middleware(req, res, next);
                 res.locals['checkbox']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -793,11 +792,12 @@ describe('Template Mixins', function () {
 
             it('uses locales translation property', function () {
                 var translate = sinon.stub().withArgs('field-name.label').returns('Field name');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'label': 'field-name.label'
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['checkbox']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -814,11 +814,11 @@ describe('Template Mixins', function () {
             });
 
             it('should override default className if one was specified against the field', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'className': 'overwritten'
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['checkbox']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -831,7 +831,7 @@ describe('Template Mixins', function () {
         describe('radio-group', function () {
 
             beforeEach(function () {
-                middleware = mixins({}, { translate: translate });
+                middleware = mixins({ translate: translate });
             });
 
             it('adds a function to res.locals', function () {
@@ -845,14 +845,14 @@ describe('Template Mixins', function () {
             });
 
             it('looks up field options', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         options: [{
                             label: 'Foo',
                             value: 'foo'
                         }]
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
                 render.lastCall.should.have.been.calledWith(sinon.match(function (value) {
@@ -868,11 +868,11 @@ describe('Template Mixins', function () {
             });
 
             it('looks up field label from fields.field-name.options.foo.label if not specified', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         options: ['foo', 'bar']
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
                 render.lastCall.args[0].options[0].label.should.be.equal('fields.field-name.options.foo.label');
@@ -880,7 +880,7 @@ describe('Template Mixins', function () {
             });
 
             it('looks up field label from fields.field-name.options.foo.label if not specified (object options)', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         options: [{
                             value: 'foo'
@@ -888,7 +888,7 @@ describe('Template Mixins', function () {
                             value: 'bar'
                         }]
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
                 render.lastCall.args[0].options[0].label.should.be.equal('fields.field-name.options.foo.label');
@@ -896,11 +896,11 @@ describe('Template Mixins', function () {
             });
 
             it('should have classes if one or more were specified against the field', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'className': ['abc', 'def']
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -909,10 +909,10 @@ describe('Template Mixins', function () {
             });
 
             it('should have role: radiogroup', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -921,7 +921,7 @@ describe('Template Mixins', function () {
             });
 
             it('adds `legendClassName` if it exists as a string or an array', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name-1': {
                         legend: {
                             className: 'abc def'
@@ -932,7 +932,7 @@ describe('Template Mixins', function () {
                             className: ['abc', 'def']
                         }
                     }
-                });
+                };
 
                 middleware(req, res, next);
 
@@ -949,9 +949,10 @@ describe('Template Mixins', function () {
 
             it('uses locales translation for legend if a field value isn\'t provided', function () {
                 var translate = sinon.stub().withArgs('fields.field-name.legend').returns('Field legend');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {}
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWithExactly(sinon.match({
@@ -961,9 +962,10 @@ describe('Template Mixins', function () {
 
             it('uses locales translation for hint if a field value isn\'t provided', function () {
                 var translate = sinon.stub().withArgs('fields.field-name.hint').returns('Field hint');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {}
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWithExactly(sinon.match({
@@ -972,9 +974,9 @@ describe('Template Mixins', function () {
             });
 
             it('doesn\'t add a hint if the hint doesn\'t exist in locales', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {}
-                });
+                };
                 middleware(req, res, next);
                 res.locals['radio-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWithExactly(sinon.match({
@@ -987,7 +989,7 @@ describe('Template Mixins', function () {
         describe('checkbox-group', function () {
 
             beforeEach(function () {
-                middleware = mixins({}, { translate: translate });
+                middleware = mixins({ translate: translate });
             });
 
             it('adds a function to res.locals', function () {
@@ -1001,7 +1003,7 @@ describe('Template Mixins', function () {
             });
 
             it('looks up field options', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         options: [{
                             label: 'Foo',
@@ -1014,7 +1016,7 @@ describe('Template Mixins', function () {
                             value: 'baz'
                         }]
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['checkbox-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match(function (value) {
@@ -1044,11 +1046,11 @@ describe('Template Mixins', function () {
             });
 
             it('should have classes if one or more were specified against the field', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'className': ['abc', 'def']
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['checkbox-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -1057,10 +1059,10 @@ describe('Template Mixins', function () {
             });
 
             it('should have role: group', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                     }
-                });
+                };
                 middleware(req, res, next);
                 res.locals['checkbox-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -1069,7 +1071,7 @@ describe('Template Mixins', function () {
             });
 
             it('adds `legendClassName` if it exists as a string or an array', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name-1': {
                         legend: {
                             className: 'abc def'
@@ -1080,7 +1082,7 @@ describe('Template Mixins', function () {
                             className: ['abc', 'def']
                         }
                     }
-                });
+                };
 
                 middleware(req, res, next);
 
@@ -1097,9 +1099,10 @@ describe('Template Mixins', function () {
 
             it('uses locales translation for legend if a field value isn\'t provided', function () {
                 var translate = sinon.stub().withArgs('fields.field-name.legend').returns('Field legend');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {}
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['checkbox-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWithExactly(sinon.match({
@@ -1109,9 +1112,10 @@ describe('Template Mixins', function () {
 
             it('uses locales translation for hint if a field value isn\'t provided', function () {
                 var translate = sinon.stub().withArgs('fields.field-name.hint').returns('Field hint');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {}
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['checkbox-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWithExactly(sinon.match({
@@ -1120,9 +1124,9 @@ describe('Template Mixins', function () {
             });
 
             it('doesn\'t add a hint if the hint doesn\'t exist in locales', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {}
-                });
+                };
                 middleware(req, res, next);
                 res.locals['checkbox-group']().call(res.locals, 'field-name');
                 render.should.have.been.calledWithExactly(sinon.match({
@@ -1132,7 +1136,7 @@ describe('Template Mixins', function () {
 
             describe('multiple options selected', function () {
                 beforeEach(function () {
-                    middleware = mixins({
+                    res.locals.options.fields = {
                         'field-name': {
                             options: [{
                                 label: 'Foo',
@@ -1145,7 +1149,7 @@ describe('Template Mixins', function () {
                                 value: 'baz'
                             }]
                         }
-                    });
+                    };
                 });
 
                 it('marks foo and bar as selected', function () {
@@ -1202,7 +1206,7 @@ describe('Template Mixins', function () {
         describe('select', function () {
 
             beforeEach(function () {
-                middleware = mixins({}, { translate: translate });
+                middleware = mixins({ translate: translate });
             });
 
             it('adds a function to res.locals', function () {
@@ -1216,9 +1220,9 @@ describe('Template Mixins', function () {
             });
 
             it('defaults `labelClassName` to "form-label-bold"', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {}
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['select']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -1227,11 +1231,11 @@ describe('Template Mixins', function () {
             });
 
             it('overrides `labelClassName` when set in field options', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         labelClassName: 'visuallyhidden'
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['select']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -1240,11 +1244,11 @@ describe('Template Mixins', function () {
             });
 
             it('sets all classes of `labelClassName` option', function () {
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         labelClassName: ['abc', 'def']
                     }
-                }, { translate: translate });
+                };
                 middleware(req, res, next);
                 res.locals['select']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -1254,10 +1258,11 @@ describe('Template Mixins', function () {
 
             it('includes a hint if it is defined in the locales', function () {
                 var translate = sinon.stub().withArgs('field-name.hint').returns('Field hint');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['select']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -1267,11 +1272,12 @@ describe('Template Mixins', function () {
 
             it('includes a hint if it is defined in translation', function () {
                 var translate = sinon.stub().withArgs('field-name.hint').returns('Field hint');
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'hint': 'field-name.hint'
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['select']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -1281,11 +1287,12 @@ describe('Template Mixins', function () {
 
             it('does not include a hint if it is not defined in translation', function () {
                 var translate = sinon.stub().withArgs('field-name.hint').returns(null);
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         'hint': 'field-name.hint'
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['select']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
@@ -1295,13 +1302,14 @@ describe('Template Mixins', function () {
 
             it('sets labels to an empty string for translations that are returned as `undefined`', function () {
                 var translate = sinon.stub().returns(undefined);
-                middleware = mixins({
+                res.locals.options.fields = {
                     'field-name': {
                         options: [
                             ''
                         ]
                     }
-                }, { translate: translate });
+                };
+                middleware = mixins({ translate: translate });
                 middleware(req, res, next);
                 res.locals['select']().call(res.locals, 'field-name');
                 render.lastCall.should.have.been.calledWith(sinon.match(function (value) {
@@ -1320,11 +1328,15 @@ describe('Template Mixins', function () {
 
     describe('without stubbed Hogan', function () {
 
+        beforeEach(function () {
+            middleware = mixins();
+        });
+
         it('looks up variables within the field key', function () {
             res.locals.foo= 'bar';
-            middleware = mixins({
+            res.locals.options.fields = {
                 'bar-field-name': {}
-            });
+            };
             middleware(req, res, next);
             res.locals['input-text']().call(res.locals, '{{foo}}-field-name').should.contain('id="bar-field-name"');
         });
@@ -1332,26 +1344,22 @@ describe('Template Mixins', function () {
         describe('date', function () {
 
             beforeEach(function () {
-                middleware = mixins();
+                middleware(req, res, next);
             });
 
             it('adds a function to res.locals', function () {
-                middleware(req, res, next);
                 res.locals['date'].should.be.a('function');
             });
 
             it('returns a function', function () {
-                middleware(req, res, next);
                 res.locals['date']().should.be.a('function');
             });
 
             it('formats a date', function () {
-                middleware(req, res, next);
                 res.locals['date']().call(res.locals, '2015-03-26').should.equal('26 March 2015');
             });
 
             it('applys a date format if specified', function () {
-                middleware(req, res, next);
                 res.locals['date']().call(res.locals, '2015-03|MMMM YYYY').should.equal('March 2015');
             });
 
@@ -1360,146 +1368,122 @@ describe('Template Mixins', function () {
         describe('time', function () {
 
             beforeEach(function () {
-                middleware = mixins();
+                middleware(req, res, next);
             });
 
             it('adds a function to res.locals', function () {
-                middleware(req, res, next);
                 res.locals['time'].should.be.a('function');
             });
 
             it('returns a function', function () {
-                middleware(req, res, next);
                 res.locals['time']().should.be.a('function');
             });
 
             it('changes 12:00am to midnight', function () {
-                middleware(req, res, next);
                 res.locals['time']().call(res.locals, '26 March 2015 12:00am').should.equal('26 March 2015 midnight');
             });
 
             it('changes 12:00pm to midday', function () {
-                middleware(req, res, next);
                 res.locals['time']().call(res.locals, '26 March 2015 12:00pm').should.equal('26 March 2015 midday');
             });
 
             it('changes leading 12:00am to Midnight', function () {
-                middleware(req, res, next);
                 res.locals['time']().call(res.locals, '12:00am 26 March 2015').should.equal('Midnight 26 March 2015');
             });
 
             it('changes leading 12:00pm to Midday', function () {
-                middleware(req, res, next);
                 res.locals['time']().call(res.locals, '12:00pm 26 March 2015').should.equal('Midday 26 March 2015');
             });
 
             it('should pass through other times', function () {
-                middleware(req, res, next);
                 res.locals['time']().call(res.locals, '6:30am 26 March 2015').should.equal('6:30am 26 March 2015');
             });
         });
 
         describe('uppercase', function () {
             beforeEach(function () {
-                middleware = mixins();
+                middleware(req, res, next);
             });
 
             it('adds a function to res.locals', function () {
-                middleware(req, res, next);
                 res.locals['uppercase'].should.be.a('function');
             });
 
             it('returns a function', function () {
-                middleware(req, res, next);
                 res.locals['uppercase']().should.be.a('function');
             });
 
             it('changes text to uppercase', function () {
-                middleware(req, res, next);
                 res.locals['uppercase']().call(res.locals, 'abcdEFG').should.equal('ABCDEFG');
             });
 
             it('returns an empty string if no text given', function () {
-                middleware(req, res, next);
                 res.locals['uppercase']().call(res.locals).should.equal('');
             });
         });
 
         describe('lowercase', function () {
             beforeEach(function () {
-                middleware = mixins();
+                middleware(req, res, next);
             });
 
             it('adds a function to res.locals', function () {
-                middleware(req, res, next);
                 res.locals['lowercase'].should.be.a('function');
             });
 
             it('returns a function', function () {
-                middleware(req, res, next);
                 res.locals['lowercase']().should.be.a('function');
             });
 
             it('changes text to lowercase', function () {
-                middleware(req, res, next);
                 res.locals['lowercase']().call(res.locals, 'abcdEFG').should.equal('abcdefg');
             });
 
             it('returns an empty string if no text given', function () {
-                middleware(req, res, next);
                 res.locals['lowercase']().call(res.locals).should.equal('');
             });
         });
 
         describe('currency', function () {
             beforeEach(function () {
-                middleware = mixins();
+                middleware(req, res, next);
             });
 
             it('adds a function to res.locals', function () {
-                middleware(req, res, next);
                 res.locals['currency'].should.be.a('function');
             });
 
             it('returns a function', function () {
-                middleware(req, res, next);
                 res.locals['currency']().should.be.a('function');
             });
 
             it('formats whole numbers with no decimal places', function () {
-                middleware(req, res, next);
                 res.locals['currency']().call(res.locals, '3.00').should.equal('£3');
             });
 
             it('formats 3.50 to two decimal places', function () {
-                middleware(req, res, next);
                 res.locals['currency']().call(res.locals, '3.50').should.equal('£3.50');
             });
 
             it('formats and rounds 3.567 to two decimal places', function () {
-                middleware(req, res, next);
                 res.locals['currency']().call(res.locals, '3.567').should.equal('£3.57');
             });
 
             it('formats 4.5678 to two decimal places from a local variable', function () {
-                middleware(req, res, next);
                 res.locals.value = 4.5678;
                 res.locals['currency']().call(res.locals, '{{value}}').should.equal('£4.57');
             });
 
             it('returns non float text as is', function () {
-                middleware(req, res, next);
                 res.locals['currency']().call(res.locals, 'test').should.equal('test');
             });
 
             it('returns non float template text as is', function () {
-                middleware(req, res, next);
                 res.locals.value = 'test';
                 res.locals['currency']().call(res.locals, '{{value}}').should.equal('test');
             });
 
             it('returns an empty string if no text given', function () {
-                middleware(req, res, next);
                 res.locals['currency']().call(res.locals).should.equal('');
             });
         });
@@ -1507,27 +1491,22 @@ describe('Template Mixins', function () {
         describe('hyphenate', function () {
 
             beforeEach(function () {
-                Hogan = require('hogan.js');
-                middleware = mixins();
+                middleware(req, res, next);
             });
 
             it('adds a function to res.locals', function () {
-                middleware(req, res, next);
                 res.locals['hyphenate'].should.be.a('function');
             });
 
             it('returns a function', function () {
-                middleware(req, res, next);
                 res.locals['hyphenate']().should.be.a('function');
             });
 
             it('hyphenates a string with a single whitespace character', function () {
-                middleware(req, res, next);
                 res.locals['hyphenate']().call(res.locals, 'apple blackberry').should.equal('apple-blackberry');
             });
 
             it('hyphenates a string with multiple whitespace characters', function () {
-                middleware(req, res, next);
                 res.locals['hyphenate']().call(res.locals, 'apple  blackberry   cherry').should.equal('apple-blackberry-cherry');
             });
 
@@ -1536,43 +1515,35 @@ describe('Template Mixins', function () {
         describe('url', function () {
 
             beforeEach(function () {
-                middleware = mixins();
+                middleware(req, res, next);
             });
 
             it('prepends the baseUrl to relative paths', function () {
                 req.baseUrl = '/base';
-                middleware(req, res, next);
                 res.locals.url().call(res.locals, './path').should.equal('/base/path');
                 res.locals.url().call(res.locals, 'path').should.equal('/base/path');
             });
 
             it('returns path if baseUrl is not set', function () {
                 req.baseUrl = undefined;
-                middleware(req, res, next);
                 res.locals.url().call(res.locals, 'path').should.equal('path');
                 res.locals.url().call(res.locals, './path').should.equal('./path');
             });
 
             it('does not prepend the baseUrl to absolute paths', function () {
                 req.baseUrl = '/base';
-                middleware(req, res, next);
                 res.locals.url().call(res.locals, '/path').should.equal('/path');
             });
 
             it('supports urls defined in template placeholders', function () {
                 req.baseUrl = '/base';
                 res.locals.href = './link';
-                middleware(req, res, next);
                 res.locals.url().call(res.locals, '{{href}}').should.equal('/base/link');
             });
 
         });
 
         describe('Multiple lambdas', function () {
-
-            beforeEach(function () {
-                middleware = mixins();
-            });
 
             it('recursively runs lambdas wrapped in other lambdas correctly', function () {
                 middleware(req, res, next);


### PR DESCRIPTION
No longer requires the field config to be passed as an argument to mixins constructor, only general translation settings. Field settings will now be found at `res.locals.options.fields`.

This allows template mixins to be able to use dynamic field configuration as set in proposed controller `configure` method - https://github.com/UKHomeOfficeForms/hof-form-controller/pull/4