### PR TITLE
Feature - return html in renderField if found

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -516,6 +516,9 @@ module.exports = function (options, deprecated) {
 
         res.locals.renderField = function () {
             return function () {
+                if (this.html) {
+                    return this.html;
+                }
                 var mixin = this.mixin || 'input-text';
                 if (mixin && res.locals[mixin] && typeof res.locals[mixin] === 'function') {
                     return res.locals[mixin]().call(Object.assign({}, res.locals, this), this.key);

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1557,6 +1557,15 @@ describe('Template Mixins', function () {
                 res.locals['input-text'].restore();
             });
 
+            it('returns the field\'s html if defined', function () {
+                var html = '<div>Prerendered HTML</div>';
+                var field = {
+                    key: 'date-field',
+                    html: html
+                };
+                res.locals.renderField().call(field).should.be.equal(html);
+            });
+
             it('looks up a mixin from res.locals and calls it', function () {
                 var field = {
                     key: 'my-field',


### PR DESCRIPTION
Components prerender html to a string, this should be returned in renderField if present, rather than looking up a mixin