### PR TITLE
Support calling `renderField` with a field name argument

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -515,7 +515,15 @@ module.exports = function (options, deprecated) {
         };
 
         res.locals.renderField = function () {
-            return function () {
+            return function (key) {
+                if (key) {
+                    var field = this.fields.find(function (f) { return f.key === key; });
+                    if (field) {
+                        Object.assign(this, field);
+                    } else {
+                        throw new Error('Could not find field: ' + key);
+                    }
+                }
                 if (this.html) {
                     return this.html;
                 }

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1576,6 +1576,17 @@ describe('Template Mixins', function () {
                     .and.calledWith('my-field');
             });
 
+            it('uses the field from the fields config if a key is passed', function () {
+                var options = {
+                    fields: [
+                        { key: 'some-field' }
+                    ]
+                };
+                res.locals.renderField().call(options, 'some-field');
+                inputTextStub.should.have.been.calledOnce
+                    .and.calledWith('some-field');
+            });
+
             it('defaults to input-text if mixin omitted', function () {
                 var field = {
                     key: 'my-field'
@@ -1592,6 +1603,17 @@ describe('Template Mixins', function () {
                 };
                 expect(function () {
                     res.locals.renderField().call(field);
+                }).to.throw();
+            });
+
+            it('throws an error if called with an undefined field', function () {
+                var options = {
+                    fields: [
+                        { key: 'some-field' }
+                    ]
+                };
+                expect(function () {
+                    res.locals.renderField().call(options, 'not-a-field');
                 }).to.throw();
             });
 


### PR DESCRIPTION
This will allow templates to call `{{#renderField}}field-name{{/renderField}}` as well as using `renderField` inside iterators.