### PR TITLE
Bugfix - Render components as children, also disable autorender by pa…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ module.exports = {
 
 If mixin is omitted `input-text` will be used
 
+To disable auto-rendering of a field, set `disableRender: true` in the field config. This is required when using the `child` element rendering functionality to prevent the field being rendered multiple times.
+
 ## Options
 
 - `className`: A string or array of string class names.
@@ -118,6 +120,6 @@ If mixin is omitted `input-text` will be used
 - `selected`: Applicable to `select`, `checkbox`, and `radio` controls. Will render the selected HTML option/element selected or checked.
 - `legend`: Applicable to `radio` button controls, which are wrapped in a HTML `fieldset` with a `legend` element.
 - `legendClassName`: Applied as a class name to HTML `legend` attribute.
-- `toggle`: Can be used to toggle the display of the HTML element with a matching `id`. See [passports-frontend-toolkit](https://github.com/UKHomeOffice/passports-frontend-toolkit/blob/master/assets/javascript/progressive-reveal.js) for details.
+- `toggle`: Can be used to toggle the display of the HTML element with a matching `id`. See [hof-frontend-toolkit](https://github.com/UKHomeOfficeForms/hof-frontend-toolkit/blob/master/assets/javascript/progressive-reveal.js) for details.
 - `attributes`: A hash of key/value pairs applicable to a HTML `textarea` field. Each key/value is assigned as an attribute of the `textarea`. For example `spellcheck="true"`.
-- `child`: Render a child partial beneath each option in an `optionGroup`. Accepts a custom mustache template string, a custom partial in the format `partials/{your-partial-name}` or a template mixin key which will be rendered within a panel element partial.
+- `child`: Render a child partial beneath each option in an `optionGroup`. Accepts a custom mustache template string, a custom partial in the format `partials/{your-partial-name}`, `'html'` which is used to specify the html for the field has already been prerendered, such as in [hof-component-date](https://github.com/UKHomeOfficeForms/hof-component-date) or a template mixin key which will be rendered within a panel element partial.

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -121,7 +121,7 @@ module.exports = function (options, deprecated) {
             if (match) {
                 res.locals.partials = res.locals.partials || {};
                 return fs.readFileSync(res.locals.partials['partials-' + match[1]] + '.' + viewEngine).toString();
-            } else if (res.locals[child]) {
+            } else if (child === 'html' || res.locals[child]) {
                 var panelPath = path.join(viewsDirectory, PANELMIXIN + '.' + viewEngine);
                 return fs.readFileSync(panelPath).toString();
             } else {
@@ -187,8 +187,20 @@ module.exports = function (options, deprecated) {
                     return template.render(Object.assign({
                         renderMixin: function () {
                             return function () {
-                                if (this.child && this[this.child]) {
-                                    return this[this.child]().call(this, this.toggle);
+                                if (this.child) {
+                                    if (this.child === 'html') {
+                                        try {
+                                            var key = this.toggle;
+                                            return res.locals.fields.find(function (field) {
+                                                return field.key === key;
+                                            }).html;
+                                        } catch (err) {
+                                            next(new Error('Error: html property not set on field: ' + this.toggle + '. Did you forget to use a component?'));
+                                        }
+                                    }
+                                    if (this[this.child]) {
+                                        return this[this.child]().call(this, this.toggle);
+                                    }
                                 }
                             };
                         }
@@ -524,12 +536,15 @@ module.exports = function (options, deprecated) {
                         throw new Error('Could not find field: ' + key);
                     }
                 }
+                if (this.disableRender) {
+                    return null;
+                }
                 if (this.html) {
                     return this.html;
                 }
                 var mixin = this.mixin || 'input-text';
                 if (mixin && res.locals[mixin] && typeof res.locals[mixin] === 'function') {
-                    return res.locals[mixin]().call(Object.assign({}, res.locals, this), this.key);
+                    return res.locals[mixin]().call(Object.assign({}, res.locals), this.key);
                 } else {
                     throw new Error('Mixin: "' + mixin + '" not found');
                 }

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -179,31 +179,33 @@ module.exports = function (options, deprecated) {
             });
         }
 
+        function renderMixin() {
+            return function () {
+                if (this.child) {
+                    if (this.child === 'html') {
+                        try {
+                            var key = this.toggle;
+                            return res.locals.fields.find(function (field) {
+                                return field.key === key;
+                            }).html;
+                        } catch (err) {
+                            next(new Error('Error: html property not set on field: ' + this.toggle + '. Did you forget to use a component?'));
+                        }
+                    }
+                    if (this[this.child]) {
+                        return this[this.child]().call(this, this.toggle);
+                    }
+                }
+            };
+        }
+
         function renderChild() {
             return function () {
                 if (this.child) {
                     var templateString = getTemplate(this.child, this.toggle);
                     var template = Hogan.compile(templateString);
                     return template.render(Object.assign({
-                        renderMixin: function () {
-                            return function () {
-                                if (this.child) {
-                                    if (this.child === 'html') {
-                                        try {
-                                            var key = this.toggle;
-                                            return res.locals.fields.find(function (field) {
-                                                return field.key === key;
-                                            }).html;
-                                        } catch (err) {
-                                            next(new Error('Error: html property not set on field: ' + this.toggle + '. Did you forget to use a component?'));
-                                        }
-                                    }
-                                    if (this[this.child]) {
-                                        return this[this.child]().call(this, this.toggle);
-                                    }
-                                }
-                            };
-                        }
+                        renderMixin: renderMixin.bind(this)
                     }, res.locals, this), _.mapObject(res.locals.partials, function (path) {
                         return Hogan.compile(fs.readFileSync(path + '.' + viewEngine).toString());
                     }));

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1557,6 +1557,15 @@ describe('Template Mixins', function () {
                 res.locals['input-text'].restore();
             });
 
+            it('returns null if disableRender is set to true', function () {
+                var field = {
+                    key: 'my-field',
+                    mixin: 'input-text',
+                    disableRender: true
+                };
+                expect(res.locals.renderField().call(field)).to.be.equal(null);
+            });
+
             it('returns the field\'s html if defined', function () {
                 var html = '<div>Prerendered HTML</div>';
                 var field = {
@@ -1703,6 +1712,27 @@ describe('Template Mixins', function () {
                         key: 'value'
                     };
                     renderChild.call(fields['field-name'].options[0]).should.be.equal('<h1>Title</h1>\n<p>The content</p>\n');
+                    sinon.stub(Hogan, 'compile').returns({
+                        render: render
+                    });
+                });
+
+                it('renders raw html in a panel if specified', function () {
+                    Hogan.compile.restore();
+                    options[0] = {
+                        child: 'html',
+                        toggle: 'child-field-name'
+                    };
+                    res.locals.fields = [
+                        {
+                            key: 'child-field-name',
+                            html: '<div>some html</div>'
+                        }
+                    ];
+                    middleware(req, res, next);
+                    res.locals['radio-group']().call(res.locals, 'field-name');
+                    renderChild = render.lastCall.args[0].renderChild();
+                    renderChild.call(fields['field-name'].options[0]).should.be.equal('<div id="child-field-name-panel" class="reveal js-hidden">\n    <div class="panel-indent">\n<div>some html</div>    </div>\n</div>\n');
                     sinon.stub(Hogan, 'compile').returns({
                         render: render
                     });


### PR DESCRIPTION
…ssing a key

* Set `disableRender: true` in field config to prevent autorender with renderField mixin. This is useful when rendering a field as a child of another field as prevents duplicate rendering.
* Added `html` option to renderChild, if child is set to `'html'` in option config, the element specified in `toggle` will be looked up in res.locals.fields, and the `html` property of this field will be rendered into a panel - useful for component rendering as children