### PR TITLE
Support use of `renderField` with a key inside a loop

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -517,7 +517,8 @@ module.exports = function (options, deprecated) {
         res.locals.renderField = function () {
             return function (key) {
                 if (key) {
-                    var field = this.fields.find(function (f) { return f.key === key; });
+                    var fields = this.fields || res.locals.fields;
+                    var field = fields.find(function (f) { return f.key === key; });
                     if (field) {
                         Object.assign(this, field);
                     } else {

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1587,6 +1587,15 @@ describe('Template Mixins', function () {
                     .and.calledWith('some-field');
             });
 
+            it('uses the field from res.locals if a key is passed and no `fields` exist in local scope', function () {
+                res.locals.fields = [
+                    { key: 'some-field' }
+                ];
+                res.locals.renderField().call({}, 'some-field');
+                inputTextStub.should.have.been.calledOnce
+                    .and.calledWith('some-field');
+            });
+
             it('defaults to input-text if mixin omitted', function () {
                 var field = {
                     key: 'my-field'


### PR DESCRIPTION
Inside a loop the scope of `this` in a template mixin is changed, so this method can fail if used as follows:

```
{{#fields}}
  {{#renderField}}{{key}}{{/renderField}}
{{/fields}}
```

Updating to allow fields to be read from `res.locals` if they are not present on `this` allows use with a key inside a loop.