### PR TITLE
Use full view hierarchy for loading partial templates

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -47,6 +47,8 @@ module.exports = function (options, deprecated) {
         'partials/forms/option-group'
     ];
 
+    var compiled = {};
+
     function maxlength(field) {
         var validation = field.validate || [];
         var ml = _.findWhere(validation, { type: 'maxlength' }) || _.findWhere(validation, { type: 'exactlength' });
@@ -85,7 +87,10 @@ module.exports = function (options, deprecated) {
 
         // wrap in try catch to throw an error if any one template cannot be resolved
         try {
-            var compiled = _.chain(PARTIALS).map(function (relativeTemplatePath) {
+            PARTIALS.forEach(function (relativeTemplatePath) {
+                if (compiled[relativeTemplatePath]) {
+                    return;
+                }
                 var viewExtension = '.' + viewEngine;
                 var engines = {};
                 engines[viewExtension] = {};
@@ -98,8 +103,8 @@ module.exports = function (options, deprecated) {
                     throw new Error('Could not find template file: ' + relativeTemplatePath);
                 }
                 var compiledTemplate = Hogan.compile(fs.readFileSync(view.path).toString());
-                return [relativeTemplatePath, compiledTemplate];
-            }).object().value();
+                compiled[relativeTemplatePath] = compiledTemplate;
+            });
         } catch (e) {
             return next(e);
         }

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -46,13 +46,6 @@ module.exports = function (options, deprecated) {
         'partials/forms/textarea-group',
         'partials/forms/option-group'
     ];
-    var compiled = _.chain(PARTIALS).map(function (relativeTemplatePath) {
-        var viewExtension = '.' + viewEngine;
-        var templatePath = path.join(viewsDirectory, relativeTemplatePath + viewExtension);
-        var compiledTemplate = Hogan.compile(fs.readFileSync(templatePath).toString());
-
-        return [relativeTemplatePath, compiledTemplate];
-    }).object().value();
 
     function maxlength(field) {
         var validation = field.validate || [];
@@ -86,6 +79,30 @@ module.exports = function (options, deprecated) {
     }
 
     return function (req, res, next) {
+
+        var roots = [].concat(req.app.get('views')).concat(viewsDirectory);
+        var View = req.app.get('view');
+
+        // wrap in try catch to throw an error if any one template cannot be resolved
+        try {
+            var compiled = _.chain(PARTIALS).map(function (relativeTemplatePath) {
+                var viewExtension = '.' + viewEngine;
+                var engines = {};
+                engines[viewExtension] = {};
+                var view = new View(relativeTemplatePath, {
+                    defaultEngine: viewEngine,
+                    root: roots,
+                    engines: engines
+                });
+                if (!view.path) {
+                    throw new Error('Could not find template file: ' + relativeTemplatePath);
+                }
+                var compiledTemplate = Hogan.compile(fs.readFileSync(view.path).toString());
+                return [relativeTemplatePath, compiledTemplate];
+            }).object().value();
+        } catch (e) {
+            return next(e);
+        }
 
         var hoganRender = function (text, ctx) {
             if (!text) { return ''; }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "dependencies": {
     "hogan.js": "^3.0.2",
     "moment": "^2.13.0",
-    "reqres": "^1.3.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
@@ -43,7 +42,7 @@
     "express": "^4.15.2",
     "istanbul": "^0.4.3",
     "mocha": "^2.4.5",
-    "reqres": "^1.2.2",
+    "reqres": "^1.3.0",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "snyk": "^1.14.3"

--- a/package.json
+++ b/package.json
@@ -34,13 +34,16 @@
   "dependencies": {
     "hogan.js": "^3.0.2",
     "moment": "^2.13.0",
+    "reqres": "^1.3.0",
     "underscore": "^1.8.3"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "eslint": "^2.10.2",
+    "express": "^4.15.2",
     "istanbul": "^0.4.3",
     "mocha": "^2.4.5",
+    "reqres": "^1.2.2",
     "sinon": "^1.17.4",
     "sinon-chai": "^2.8.0",
     "snyk": "^1.14.3"

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -3,15 +3,16 @@ var mixins = require('../lib/template-mixins');
 var _ = require('underscore');
 var Hogan = require('hogan.js');
 var fs = require('fs');
+var reqres = require('reqres');
 
 describe('Template Mixins', function () {
 
     var req, res, next, render, middleware;
 
     beforeEach(function () {
-        req = {
+        req = reqres.req({
             translate: function (a) { return a; }
-        };
+        });
         res = {
             locals: {
                 options: {


### PR DESCRIPTION
This allows an implementation to override any partial template by implementing that partial at the project level instead of being fixed to the templates that ship with this module.

Utilise the in-built lookup behaviour from within express to find templates.