### PR TITLE
Only use the aria-required attribute on the option-group mixin if the…

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -254,6 +254,7 @@ module.exports = function (options, deprecated) {
                 legend: t(legendValue),
                 legendClassName: legendClassName,
                 role: opts.type === 'radio' ? 'radiogroup' : 'group',
+                ariaRequired: opts.type === 'radio' ? 'true' : '',
                 hint: conditionalTranslate(getTranslationKey(field, key, 'hint')),
                 options: _.map(field.options, function (obj) {
                     var selected = false, label, value, toggle, child;

--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -254,7 +254,7 @@ module.exports = function (options, deprecated) {
                 legend: t(legendValue),
                 legendClassName: legendClassName,
                 role: opts.type === 'radio' ? 'radiogroup' : 'group',
-                ariaRequired: opts.type === 'radio' ? 'true' : '',
+                ariaRequired: opts.type === 'radio',
                 hint: conditionalTranslate(getTranslationKey(field, key, 'hint')),
                 options: _.map(field.options, function (obj) {
                     var selected = false, label, value, toggle, child;

--- a/partials/forms/option-group.html
+++ b/partials/forms/option-group.html
@@ -1,5 +1,5 @@
 <div id="{{key}}-group" class="form-group{{#className}} {{className}} {{/className}}{{#error}} validation-error{{/error}}">
-    <fieldset role="{{role}}" aria-required="true">
+    <fieldset role="{{role}}"{{#ariaRequired}} aria-required="true"{{/ariaRequired}}>
         <legend>
             <span{{#legendClassName}} class="{{legendClassName}}"{{/legendClassName}}>{{legend}}</span>
             {{#hint}}<span id="{{key}}-hint" class="form-hint">{{hint}}</span>{{/hint}}


### PR DESCRIPTION
… option type is radio

When the aria-required="true" attribute is on the fieldset and the role="group" (which would be the case when using checkboxes in the option-group mixin), this is an incorrect use of aria-required and fails automated accessibility checking using [aXe](https://www.deque.com/products/axe/)

This PR sets a flag if the option-group is not a radio type, and updates the partial to remove the aria-required attribute if the flag is not set.