### PR TITLE
Fix-set labelClassName to form-label by default instead of form-label-bold

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -185,7 +185,7 @@ module.exports = function (options, deprecated) {
                 type: extension.type || type(field),
                 value: this.values && this.values[key],
                 label: t(lKey),
-                labelClassName: classNames(field, 'labelClassName') || 'form-label-bold',
+                labelClassName: classNames(field, 'labelClassName') || 'form-label',
                 hint: hint,
                 hintId: extension.hintId || (hint ? key + '-hint' : null),
                 error: this.errors && this.errors[key],

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -217,11 +217,11 @@ describe('Template Mixins', function () {
                 }));
             });
 
-            it('sets `labelClassName` to "form-label-bold" by default', function () {
+            it('sets `labelClassName` to "form-label" by default', function () {
                 middleware(req, res, next);
                 res.locals['input-text']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
-                    labelClassName: 'form-label-bold'
+                    labelClassName: 'form-label'
                 }));
             });
 
@@ -675,14 +675,14 @@ describe('Template Mixins', function () {
                 }));
             });
 
-            it('sets `labelClassName` to "form-label-bold" by default', function () {
+            it('sets `labelClassName` to "form-label" by default', function () {
                 res.locals.options.fields = {
                     'field-name': {}
                 };
                 middleware(req, res, next);
                 res.locals['textarea']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
-                    labelClassName: 'form-label-bold'
+                    labelClassName: 'form-label'
                 }));
             });
 
@@ -1186,14 +1186,14 @@ describe('Template Mixins', function () {
                 res.locals['select']().should.be.a('function');
             });
 
-            it('defaults `labelClassName` to "form-label-bold"', function () {
+            it('defaults `labelClassName` to "form-label"', function () {
                 res.locals.options.fields = {
                     'field-name': {}
                 };
                 middleware(req, res, next);
                 res.locals['select']().call(res.locals, 'field-name');
                 render.should.have.been.calledWith(sinon.match({
-                    labelClassName: 'form-label-bold'
+                    labelClassName: 'form-label'
                 }));
             });
 


### PR DESCRIPTION
All the Hof apps have custom css to override the form-label-bold class to remove the bold.  This is to remove the need for this.