### PR TITLE
Eslintrc setup for es6

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,7 @@
 {
     "env": {
-        "node": true
+        "node": true,
+        "es6": true
     },
     "extends": "eslint:recommended",
     "rules": {


### PR DESCRIPTION
This seems to be an old way of setting up our eslinrc but it was an easy change to make to accept es6.  Should I change our eslintrc to reflect our other apps i.e. to use the eslint-config-homeoffice?