### PR TITLE
Upgrade govuk elements: Replace panel-indent with panel panel-border-narrow for new govuk elements

### DIFF
--- a/partials/mixins/panel.html
+++ b/partials/mixins/panel.html
@@ -1,5 +1,3 @@
-<div id="{{toggle}}-panel" class="reveal js-hidden">
-    <div class="panel-indent">
-        {{#renderMixin}}{{/renderMixin}}
-    </div>
+<div id="{{toggle}}-panel" class="reveal js-hidden panel panel-border-narrow">
+  {{#renderMixin}}{{/renderMixin}}
 </div>

--- a/test/spec.index.js
+++ b/test/spec.index.js
@@ -1734,7 +1734,9 @@ describe('Template Mixins', function () {
                     middleware(req, res, next);
                     res.locals['radio-group']().call(res.locals, 'field-name');
                     renderChild = render.lastCall.args[0].renderChild();
-                    renderChild.call(fields['field-name'].options[0]).should.be.equal('<div id="child-field-name-panel" class="reveal js-hidden">\n    <div class="panel-indent">\n<div>some html</div>    </div>\n</div>\n');
+                    var output = '<div id="child-field-name-panel" class="reveal js-hidden panel panel-border-narrow">\n<div>some html</div></div>';
+
+                    renderChild.call(fields['field-name'].options[0]).trim().should.be.equal(output.trim());
                     sinon.stub(Hogan, 'compile').returns({
                         render: render
                     });
@@ -1751,12 +1753,8 @@ describe('Template Mixins', function () {
                     sinon.stub(res.locals, 'input-text').returns(function (key) {
                         return Hogan.compile('<div>{{key}}</div>').render({ key: key });
                     });
-                    var output = '<div id="child-field-name-panel" class="reveal js-hidden">';
-                    output += '\n    <div class="panel-indent">\n';
-                    output += '<div>child-field-name</div>';
-                    output += '    </div>';
-                    output += '\n</div>\n';
-                    renderChild.call(_.extend({}, fields['field-name'].options[0], res.locals)).should.be.equal(output);
+                    var output = '<div id="child-field-name-panel" class="reveal js-hidden panel panel-border-narrow">\n<div>child-field-name</div></div>';
+                    renderChild.call(_.extend({}, fields['field-name'].options[0], res.locals)).trim().should.be.equal(output.trim());
                     res.locals['input-text'].restore();
                     sinon.stub(Hogan, 'compile').returns({
                         render: render
@@ -1830,12 +1828,8 @@ describe('Template Mixins', function () {
                     sinon.stub(res.locals, 'input-text').returns(function (key) {
                         return Hogan.compile('<div>{{key}}</div>').render({ key: key });
                     });
-                    var output = '<div id="child-field-name-panel" class="reveal js-hidden">';
-                    output += '\n    <div class="panel-indent">\n';
-                    output += '<div>child-field-name</div>';
-                    output += '    </div>';
-                    output += '\n</div>\n';
-                    renderChild.call(_.extend({}, fields['field-name'], res.locals)).should.be.equal(output);
+                    var output = '<div id="child-field-name-panel" class="reveal js-hidden panel panel-border-narrow">\n<div>child-field-name</div></div>';
+                    renderChild.call(_.extend({}, fields['field-name'], res.locals)).trim().should.be.equal(output.trim());
                     sinon.stub(Hogan, 'compile').returns({
                         render: render
                     });


### PR DESCRIPTION
This is dependent on the PR for hof-theme-govuk https://github.com/UKHomeOfficeForms/hof-theme-govuk/pull/2

- New govuk elements have replaced panel-indent for panel and panel-border-narrow. 
- The layout has been changed to also reflect how the sass is implemented
- The panel template could not be overriden in hof-theme-govuk because it is used here https://github.com/UKHomeOfficeForms/hof-template-mixins/blob/master/lib/template-mixins.js#L39