### PR TITLE
Override the panel.html mixin from res.locals.partials

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -139,12 +139,17 @@ module.exports = function (options, deprecated) {
         var getTemplate = function getTemplate(child) {
             var re = /^partials\/(.+)/i;
             var match = child.match(re);
+            res.locals.partials = res.locals.partials || {};
             if (match) {
-                res.locals.partials = res.locals.partials || {};
                 return fs.readFileSync(res.locals.partials['partials-' + match[1]] + '.' + viewEngine).toString();
             } else if (child === 'html' || res.locals[child]) {
                 var panelPath = path.join(viewsDirectory, PANELMIXIN + '.' + viewEngine);
-                return fs.readFileSync(panelPath).toString();
+                var localsPanelPath = path.join(res.locals.partials['partials-mixins-panel'] + '.' + viewEngine);
+                if (res.locals.partials['partials-mixins-panel']) {
+                    return fs.readFileSync(localsPanelPath).toString();
+                } else {
+                    return fs.readFileSync(panelPath).toString();
+                }
             } else {
                 return child;
             }


### PR DESCRIPTION
- This is needed as part of the upgrade to new govuk elements v3 found in [hof-theme-govuk PR](https://github.com/UKHomeOfficeForms/hof-theme-govuk/pull/2#discussion_r125605579)
- hof-theme-govuk overrides the panel to a new layout and new classes for govuk elements v3