### PR TITLE
Improve child/partial template performance

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -17,6 +17,7 @@ const PARTIALS = [
     'partials/forms/textarea-group',
     'partials/forms/option-group'
 ];
+
 // This returns a middleware that places mixins against the `res.locals` object.
 //
 // It should be given:
@@ -28,6 +29,7 @@ const PARTIALS = [
 module.exports = function (options) {
 
     const compiled = {};
+    const templateCache = {};
 
     function maxlength(field) {
         const validation = field.validate || [];
@@ -103,6 +105,15 @@ module.exports = function (options) {
             return field[property] ? field[property] : 'fields.' + key + '.' + property;
         };
 
+        function readTemplate(name) {
+            if (templateCache[name]) {
+                return templateCache[name];
+            }
+            const data = fs.readFileSync(`${name}.${options.viewEngine}`).toString();
+            templateCache[name] = data;
+            return data;
+        }
+
         /*
          * helper function which takes a child string which
          * can either be the name of a partial in the format
@@ -112,19 +123,18 @@ module.exports = function (options) {
         function getTemplate(child) {
             res.locals.partials = res.locals.partials || {};
 
-            const read = name => fs.readFileSync(`${name}.${options.viewEngine}`).toString();
 
             const re = /^partials\/(.+)/i;
             const match = child.match(re);
 
             if (match) {
-                return read(res.locals.partials['partials-' + match[1]]);
+                return readTemplate(res.locals.partials['partials-' + match[1]]);
             } else if (child === 'html' || res.locals[child]) {
                 if (res.locals.partials['partials-mixins-panel']) {
-                    return read(res.locals.partials['partials-mixins-panel']);
+                    return readTemplate(res.locals.partials['partials-mixins-panel']);
                 } else {
                     const panelPath = path.join(options.viewsDirectory, PANELMIXIN);
-                    return read(panelPath);
+                    return readTemplate(panelPath);
                 }
             } else {
                 return child;
@@ -169,7 +179,7 @@ module.exports = function (options) {
                     return template.render(Object.assign({
                         renderMixin: renderMixin.bind(this)
                     }, res.locals, this), _.mapObject(res.locals.partials, function (partialpath) {
-                        return Hogan.compile(fs.readFileSync(partialpath + '.' + options.viewEngine).toString());
+                        return readTemplate(partialpath);
                     }));
                 }
             };


### PR DESCRIPTION
Previously when rendering a child template of a radio group or checkbox we would synchronously read *every* file on `res.locals.partials` and compile them, on *every* render.

Instead apply a cache to the file reads so that each file is only read from fs once, and is persisted in memory across requests.

Also do not compile the templates prior to rendering. Hogan will compile at render time if a partial template is passed as a template string (see https://github.com/twitter/hogan.js/blob/master/lib/template.js#L59-L64) so it is not necessary to pre-compile *all* templates, when in most cases (I am aware of no exceptions in implementation outside of this module's unit tests) no partial template are actually rendered as child elements. Instead templates can be compiled dynamically as they are used.

Initial tests show a 71% reduction in (blocking) render time for https://firearms-licensing-dev.notprod.homeoffice.gov.uk/s5/company-name which has numerous child elements.

### Test timings

Mean execution time of `renderChild` across 10 page loads of firearms `/s5/company-name` (60 total executions)

Before: 0.0028s
After: 0.0008s (-71%)