### PR TITLE
Use form-control classname for style

### DIFF
--- a/partials/forms/select.html
+++ b/partials/forms/select.html
@@ -4,7 +4,7 @@
         {{#hint}}<span {{$hintId}}id="{{hintId}}" {{/hintId}}class="form-hint">{{hint}}</span>{{/hint}}
         {{#error}}<span class="error-message">{{error.message}}</span>{{/error}}
     </label>
-    <select id="{{id}}" class="{{#className}}{{className}}{{/className}}{{#error}} invalid-input{{/error}}" name="{{id}}" aria-required="{{required}}">
+    <select id="{{id}}" class="form-control{{#className}} {{className}}{{/className}}{{#error}} invalid-input{{/error}}" name="{{id}}" aria-required="{{required}}">
     {{#options}}
         <option value="{{value}}" {{#selected}}selected{{/selected}}>{{label}}</option>
     {{/options}}


### PR DESCRIPTION
Adds the classname 'form-control' to the `select` element to give it the correct appearance.