### PR TITLE
Remove snyk from regular test run

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {
-    "test": "npm run lint && npm run unit && npm run cover && npm run snyk",
+    "test": "npm run lint && npm run unit && npm run cover",
     "lint": "eslint .",
     "unit": "mocha test/ --require ./test/helpers --recursive",
     "cover": "istanbul cover _mocha -- -R dot test/ --recursive --require test/helpers",


### PR DESCRIPTION
Running snyk in CI is regular pain point since PR builds can't include the secure token. Since this module will only ever be used in the context of a larger project - which can and absolutely should run snyk on its dependency tree - then I don't think it is necessary to also protect here.