### PR TITLE
v5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-mixins",
-  "version": "5.0.1",
+  "version": "5.2.0",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This change relates to #28 - a minor bug fix / addition of functionality, which I originally applied in a patch version. Having updated with a patch version I discovered that 5.0.1 had, in fact, already been published to npm and not committed to github.

Given that I wasn't sure of the contents of this published version I thought it safer to utilise a minor version update to 5.1.0 - which npm version then informed me was already a tag in the git repository, hence the bump to 5.2.0