### PR TITLE
Allow hints on options

### DIFF
--- a/lib/template-mixins.js
+++ b/lib/template-mixins.js
@@ -247,15 +247,18 @@ module.exports = function (options) {
           let value;
           let toggle;
           let child;
+          let optionHint;
 
           if (typeof obj === 'string') {
             value = obj;
             label = 'fields.' + key + '.options.' + obj + '.label';
+            optionHint = 'fields.' + key + '.options.' + obj + '.hint';
           } else {
             value = obj.value;
             label = obj.label || 'fields.' + key + '.options.' + obj.value + '.label';
             toggle = obj.toggle;
             child = obj.child;
+            optionHint = obj.hint || 'fields.' + key + '.options.' + obj.value + '.hint';
           }
 
           if (this.values && this.values[key] !== undefined) {
@@ -271,7 +274,8 @@ module.exports = function (options) {
             type: opts.type,
             selected: selected,
             toggle: toggle,
-            child: child
+            child: child,
+            optionHint: conditionalTranslate(optionHint) || ''
           };
         }, this),
         className: classNames(field),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-mixins",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {

--- a/partials/forms/option-group.html
+++ b/partials/forms/option-group.html
@@ -1,5 +1,5 @@
 <div id="{{key}}-group" class="form-group{{#className}} {{className}} {{/className}}{{#formGroupClassName}} {{formGroupClassName}}{{/formGroupClassName}}{{#error}} validation-error{{/error}}">
-    <fieldset role="{{role}}"{{#ariaRequired}} aria-required="true"{{/ariaRequired}}>
+    <fieldset role="{{role}}"{{#ariaRequired}} aria-required="true"{{/ariaRequired}}{{#hint}} aria-describedby="{{key}}-hint"{{/hint}}>
         <legend>
             <span{{#legendClassName}} class="{{legendClassName}}"{{/legendClassName}}>{{legend}}</span>
             {{#hint}}<span id="{{key}}-hint" class="form-hint">{{hint}}</span>{{/hint}}
@@ -15,11 +15,11 @@
                     required="true"
                     {{#toggle}} data-toggle="{{toggle}}"{{/toggle}}
                     {{#selected}} checked="checked"{{/selected}}
-                    {{^error}}{{#hint}} aria-describedby="{{key}}-{{value}}-hint"{{/hint}}{{/error}}
+                    {{^error}}{{#optionHint}} aria-describedby="{{key}}-{{value}}-hint"{{/optionHint}}{{^optionHint}}{{#hint}} aria-describedby="{{key}}-hint"{{/hint}}{{/optionHint}}{{/error}}
                     {{#error}} aria-describedby="{{key}}-error" aria-invalid="true"{{/error}}
                 >
                 {{{label}}}
-                {{#hint}}<span id="{{key}}-{{value}}-hint" class="form-hint">{{hint}}</span>{{/hint}}
+                {{#optionHint}}<span id="{{key}}-{{value}}-hint" class="form-hint">{{optionHint}}</span>{{/optionHint}}
             </label>
             {{#renderChild}}{{/renderChild}}
         {{/options}}


### PR DESCRIPTION
Update template-mixins.js to pass `optionHint` containing the resolved
hint or nothing otherwise to prevent accidental references to the
parent field `hint`.

aria-describedBy is the option hint if one is present, falling back
to the hint of the parent field otherwise.

![Screenshot 2020-04-20 at 13 44 36](https://user-images.githubusercontent.com/45763982/79870312-b15d1c80-83da-11ea-8f10-b20538107742.png)