### PR TITLE
feat: add no-js message for max length to textarea hint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ node_modules
 .lock-wscript
 
 package-lock.json
+.idea

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-mixins",
-  "version": "5.2.1",
+  "version": "5.3.0",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {

--- a/partials/forms/textarea-group.html
+++ b/partials/forms/textarea-group.html
@@ -8,7 +8,7 @@
     <textarea
         name="{{id}}"
         id="{{id}}"
-        class="form-control{{#className}} {{className}}{{/className}}{{#error}} invalid-input{{/error}}"
+        class="form-control{{#className}} {{className}}{{/className}} {{#maxlength}}maxlength{{/maxlength}}{{#error}} invalid-input{{/error}}"
         aria-required="{{required}}"
         {{#maxlength}} maxlength="{{maxlength}}"{{/maxlength}}
         {{#attributes}}
@@ -17,4 +17,5 @@
         {{^error}}{{#hintId}} aria-describedby="{{hintId}}"{{/hintId}}{{/error}}
         {{#error}} aria-invalid="true" aria-describedby="{{id}}-error"{{/error}}
     >{{value}}</textarea>
+    {{#maxlength}}<span id="{{id}}-maxlength-hint"class="maxlength-hint form-hint">You can enter up to {{maxlength}} characters</span>{{/maxlength}}
 </div>


### PR DESCRIPTION
**What?**
Adds static no-js message to textareas with maxlength, letting the user know there is a limit. Changes to hof-frontend-toolkit and hof-theme-govuk make this dynamic and count down the number of characters the user has remaining.

**Why?**
To improve accessibility as currently there is no message to the user expressing that there is a character limit

**How?**
Removes the maxlength attribute, adds event listener to capture input and event listener to refresh and detect changes from assistive technologies. Updates hint below textarea displaying characters user has remaining 

**Testing?**
Added tests in hof-frontend-toolkit

**Screenshots**
<img width="608" alt="Screenshot 2020-11-09 at 17 04 05" src="https://user-images.githubusercontent.com/61828376/98572476-96d28e00-22ad-11eb-86e1-06ea2e43d3c5.png">
<img width="616" alt="Screenshot 2020-11-09 at 17 05 13" src="https://user-images.githubusercontent.com/61828376/98572625-bf5a8800-22ad-11eb-9292-88b5bca4eb49.png">

