### PR TITLE
SD-91: add maxlength character count to aria attributes of textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-mixins",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "A middleware that exposes a series of Mustache mixins on res.locals to ease usage of forms, translations, and some general needs.",
   "main": "index.js",
   "scripts": {

--- a/partials/forms/textarea-group.html
+++ b/partials/forms/textarea-group.html
@@ -14,8 +14,8 @@
         {{#attributes}}
             {{attribute}}="{{value}}"
         {{/attributes}}
-        {{^error}}{{#hintId}} aria-describedby="{{hintId}}"{{/hintId}}{{/error}}
+        {{^error}}{{#hintId}} aria-describedby="{{#maxlength}}{{id}}-maxlength-hint{{/maxlength}} {{hintId}}"{{/hintId}}{{/error}}
         {{#error}} aria-invalid="true" aria-describedby="{{id}}-error"{{/error}}
     >{{value}}</textarea>
-    {{#maxlength}}<span id="{{id}}-maxlength-hint"class="maxlength-hint form-hint">You can enter up to {{maxlength}} characters</span>{{/maxlength}}
+    {{#maxlength}}<span id="{{id}}-maxlength-hint" class="maxlength-hint form-hint" aria-live="polite">You can enter up to {{maxlength}} characters</span>{{/maxlength}}
 </div>


### PR DESCRIPTION
### What
Makes screen readers read the maximum character count of textareas when they are focused on and when the user stops typing
### Why
So that screen reader users receive the same information on how many characters they have remaining as non screen reader users do.
### How
Add counter element to `aria-describedby` of textarea and give counter element `aria-live="polite"` to make it read out when the user stops typing.